### PR TITLE
set the region of dynamoDB explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ As a one-off operation, you'll need to install the Athena JDBC driver into a lib
 
 ```
 mkdir lib
-aws s3 cp s3://athena-downloads/drivers/AthenaJDBC41-1.0.1.jar lib/
-mvn install:install-file -Dfile=lib/AthenaJDBC41-1.0.1.jar -DgroupId=com.amazonaws -DartifactId=athena.jdbc41 -Dversion=1.0.0 -Dpackaging=jar -DgeneratePom=true
+aws s3 cp s3://athena-downloads/drivers/AthenaJDBC41-1.1.0.jar lib/
+mvn install:install-file -Dfile=lib/AthenaJDBC41-1.1.0.jar -DgroupId=com.amazonaws -DartifactId=athena.jdbc41 -Dversion=1.1.0 -Dpackaging=jar -DgeneratePom=true
 ```
 
 And then, to build:

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>athena.jdbc41</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/amazonaws/services/lambda/CreateAthenaPartitionsBasedOnS3EventWithDDB.java
+++ b/src/main/java/com/amazonaws/services/lambda/CreateAthenaPartitionsBasedOnS3EventWithDDB.java
@@ -1,6 +1,8 @@
 package com.amazonaws.services.lambda;
 
 import com.amazonaws.athena.jdbc.shaded.com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.lambda.model.*;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
@@ -15,6 +17,7 @@ import com.amazonaws.services.lambda.model.PartitionConfig;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.amazonaws.services.lambda.utils.EnvironmentVariableUtils;
 import com.amazonaws.services.s3.event.S3EventNotification;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 
@@ -40,7 +43,10 @@ public class CreateAthenaPartitionsBasedOnS3EventWithDDB implements RequestHandl
 
         Collection<Partition>requiredPartitions = new HashSet<>();
         TableService tableService = new TableService();
-        DynamoDB dynamoDBClient=new DynamoDB(new AmazonDynamoDBClient(new EnvironmentVariableCredentialsProvider()));
+        AmazonDynamoDBClient ddbClient=new AmazonDynamoDBClient(new EnvironmentVariableCredentialsProvider());
+        String region = EnvironmentVariableUtils.getOptionalEnv("ATHENA_REGION", EnvironmentVariableUtils.getMandatoryEnv(("AWS_DEFAULT_REGION")));
+        ddbClient.setRegion(Region.getRegion(Regions.fromName(region)));
+        DynamoDB dynamoDBClient=new DynamoDB(ddbClient);
 
         for(S3EventNotification.S3EventNotificationRecord record:s3Event.getRecords()){
 


### PR DESCRIPTION
as decribed here: https://github.com/awslabs/serverless-cf-analysis/issues/2

It seems we need to set the region for the dynamo db client explicitly when we're using eu-west-1 for example.

I'm no Java expert so if you want to do this differently or you think this should not be needed please let me know how it should work otherwise.

Thanks!